### PR TITLE
fix(setup): use torch 2.8 for Blackwell CUDA wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -520,7 +520,7 @@ def setup(python_exe: str, ext_dir: Path, gpu_sm: int, cuda_version: int = 0) ->
     # ── PyTorch — select build based on GPU architecture / CUDA driver ── #
     if gpu_sm >= 100 or cuda_version >= 128:
         # Blackwell (RTX 50xx, B100…) — SM 12.x kernels require PyTorch 2.7+
-        torch_pkgs  = ["torch==2.7.0", "torchvision==0.22.0"]
+        torch_pkgs  = ["torch==2.8.0", "torchvision==0.23.0"]
         torch_index = "https://download.pytorch.org/whl/cu128"
         print(f"[setup] GPU SM {gpu_sm}, CUDA {cuda_version} -> PyTorch 2.7 + CUDA 12.8 (Blackwell)")
     elif gpu_sm == 0 or gpu_sm >= 70:


### PR DESCRIPTION
The custom CUDA wheel index does not provide cumesh wheels for cu128 + torch 2.7, causing Trellis2 setup to finish without required dependencies. Use torch 2.8 / torchvision 0.23 for Blackwell so the installer can resolve cu128 wheels for cumesh and flex-gemm.