### PR TITLE
Backfill tqdm in AST-injected mesh-extraction function

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -1164,6 +1164,12 @@ class Trellis2GGUFGenerator(BaseGenerator):
                             ns = _ov.__dict__
                             if "torch" not in ns:
                                 import torch as _t; ns["torch"] = _t
+                            if "tqdm" not in ns:
+                                try:
+                                    from tqdm import tqdm as _tq
+                                    ns["tqdm"] = _tq
+                                except ImportError:
+                                    ns["tqdm"] = lambda _it, *a, **k: _it
                             exec(compile(func_src, str(_pf), "exec"), ns)  # noqa: S102
                             print("[Trellis2] Injected tiled_flexible_dual_grid_to_mesh "
                                   "into o_voxel.convert")


### PR DESCRIPTION
## Symptom
Generation dies at the final mesh-extraction step with `NameError: name 'tqdm' is not defined` (#11).

## Root cause
`_patch_o_voxel_convert` extracts `tiled_flexible_dual_grid_to_mesh` from `trellis2_gguf_patch/flexible_dual_grid.py` via AST and execs only the function body into `o_voxel.convert`'s namespace, deliberately skipping the patch file's top-level imports (they pull in spconv internals that don't resolve via `importlib`). It backfills `torch` into that namespace before the exec, but not `tqdm`, which the tile loop also uses.

## Fix
Backfill `tqdm` the same way `torch` is already backfilled, with a no-op passthrough fallback if `tqdm` somehow isn't importable — matching the pattern the issue's reporter confirmed works locally.

## Verification
No test suite ships with this extension (and the real path needs torch/spconv/o_voxel). Reproduced the bug and the fix in isolation by extracting the same AST-exec logic against a stand-in function that calls `tqdm(...)` without importing it:
- Without the tqdm backfill: `NameError: name 'tqdm' is not defined` (matches the reported traceback).
- With the tqdm backfill: runs clean, same output.

Fixes #11.